### PR TITLE
YAMLの整形処理を実装

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,12 +6,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var formatType string
+
 var rootCmd = &cobra.Command{
 	Use:   "prettify",
-	Short: "多機能フォーマッターCLIツール",
+	Short: "多機能フォーマッターCLIツール(JSON / YAML)",
 	Run: func(cmd *cobra.Command, args []string) {
-		cli.Run(args)
+		cli.Run(formatType, args)
 	},
+}
+
+func init() {
+	rootCmd.Flags().StringVarP(&formatType, "type", "t", "json", "整形対象のタイプ（json / yaml）")
 }
 
 func Execute() {

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require github.com/spf13/cobra v1.9.1
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,4 +7,6 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/infrastructure/yaml_formatter.go
+++ b/infrastructure/yaml_formatter.go
@@ -1,0 +1,20 @@
+package infrastructure
+
+import "gopkg.in/yaml.v2"
+
+type YAMLFormatter struct{}
+
+func (f *YAMLFormatter) Format(input []byte) (string, error) {
+	var data interface{}
+	err := yaml.Unmarshal(input, &data)
+	if err != nil {
+		return "", err
+	}
+
+	output, err := yaml.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}

--- a/interface/cli/json_runner.go
+++ b/interface/cli/json_runner.go
@@ -6,7 +6,7 @@ import (
 	"prettify/usecase"
 )
 
-func Run(args []string) {
+func Run(formatType string, args []string) {
 	var data []byte
 	var err error
 
@@ -20,7 +20,7 @@ func Run(args []string) {
 		os.Exit(1)
 	}
 
-	output, err := usecase.FormatJSON(data)
+	output, err := usecase.FormatInput(data, formatType)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "整形失敗: %v\n", err)
 		os.Exit(1)

--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,3 @@
+app: { name: MyApp, version: 1.0.0, description: A simple application for demonstration purposes. }
+database: { host: localhost, port: 5432, username: user, password: password, dbname: mydatabase }
+features: { logging: true, caching: false, analytics: { enabled: true, provider: google } }

--- a/usecase/foramt_dispatcher.go
+++ b/usecase/foramt_dispatcher.go
@@ -1,0 +1,22 @@
+package usecase
+
+import (
+	"errors"
+	"prettify/domain"
+	"prettify/infrastructure"
+)
+
+func FormatInput(input []byte, formatType string) (string, error) {
+	var formatter domain.Formatter
+
+	switch formatType {
+	case "json":
+		formatter = &infrastructure.JSONFormatter{}
+	case "yaml":
+		formatter = &infrastructure.YAMLFormatter{}
+	default:
+		return "", errors.New("未対応のフォーマットタイプです")
+	}
+
+	return formatter.Format(input)
+}


### PR DESCRIPTION
# 概要
YAMLフォーマット機能の追加

## 変更内容
- YAMLフォーマッターの実装
- フォーマットタイプを指定するフラグの追加（-t または --type）
- フォーマッターの振り分け処理の実装

## 動作確認方法
1. 以下のコマンドでJSONフォーマット

```
$ go run main.go -type yaml test.yaml
```