### PR TITLE
XMLの整形処理を実装

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,14 +10,14 @@ var formatType string
 
 var rootCmd = &cobra.Command{
 	Use:   "prettify",
-	Short: "多機能フォーマッターCLIツール(JSON / YAML)",
+	Short: "多機能フォーマッターCLIツール(JSON / YAML / XML)",
 	Run: func(cmd *cobra.Command, args []string) {
 		cli.Run(formatType, args)
 	},
 }
 
 func init() {
-	rootCmd.Flags().StringVarP(&formatType, "type", "t", "json", "整形対象のタイプ（json / yaml）")
+	rootCmd.Flags().StringVarP(&formatType, "type", "t", "json", "整形対象のタイプ（json / yaml / xml）")
 }
 
 func Execute() {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.2
 require github.com/spf13/cobra v1.9.1
 
 require (
+	github.com/go-xmlfmt/xmlfmt v1.1.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/go-xmlfmt/xmlfmt v1.1.3 h1:t8Ey3Uy7jDSEisW2K3somuMKIpzktkWptA0iFCnRUWY=
+github.com/go-xmlfmt/xmlfmt v1.1.3/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/infrastructure/xml_formatter.go
+++ b/infrastructure/xml_formatter.go
@@ -1,0 +1,10 @@
+package infrastructure
+
+import "github.com/go-xmlfmt/xmlfmt"
+
+type XMLFormatter struct{}
+
+func (f *XMLFormatter) Format(input []byte) (string, error) {
+	output := xmlfmt.FormatXML(string(input), "", "  ")
+	return string(output), nil
+}

--- a/test.xml
+++ b/test.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><library><book><title>Go言語によるプログラミング</title><author>山田太郎</author><year>2021</year><price>3000</price></book><book><title>Python入門</title><author>佐藤花子</author><year>2020</year><price>2500</price></book><book><title>JavaScriptの基礎</title><author>鈴木一郎</author><year>2019</year><price>2800</price></book></library>

--- a/usecase/foramt_dispatcher.go
+++ b/usecase/foramt_dispatcher.go
@@ -14,6 +14,8 @@ func FormatInput(input []byte, formatType string) (string, error) {
 		formatter = &infrastructure.JSONFormatter{}
 	case "yaml":
 		formatter = &infrastructure.YAMLFormatter{}
+	case "xml":
+		formatter = &infrastructure.XMLFormatter{}
 	default:
 		return "", errors.New("未対応のフォーマットタイプです")
 	}


### PR DESCRIPTION
# 概要
XMLフォーマット機能の追加

## 変更内容
- XMLフォーマッターの実装
- フォーマットタイプを指定するフラグの追加（-t または --type）
- フォーマッターの振り分け処理の実装

## 動作確認方法
1. 以下のコマンドでJSONフォーマット

```
$ go run main.go -type yaml test.xml
```